### PR TITLE
Add Oracle, SQL Server, and Databricks dialect mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![CI](https://github.com/leebase/csv2ddl/actions/workflows/ci.yml/badge.svg)
 
-A Python tool that analyzes CSV files and generates optimized DDL statements for creating tables in various SQL databases. Currently supports Snowflake, SQLite, Postgres, and MySQL dialects, with an extensible architecture for adding more databases.
+A Python tool that analyzes CSV files and generates optimized DDL statements for creating tables in various SQL databases. Currently supports Snowflake, SQLite, Postgres, MySQL, Oracle, SQL Server, and Databricks dialects, with an extensible architecture for adding more databases.
 
 ## Features
 
 - **Multiple File Formats**: Supports CSV and Excel files (.csv, .xlsx)
 - **Automatic Type Inference**: Intelligently detects dates, numbers, and strings from data
 - **Optimal Sizing**: Calculates appropriate column sizes based on actual data content
-- **Multiple SQL Dialects**: Generate DDL for Snowflake, SQLite, Postgres, and MySQL, and easily add more
+- **Multiple SQL Dialects**: Generate DDL for Snowflake, SQLite, Postgres, MySQL, Oracle, SQL Server, and Databricks, and easily add more
 - **Safe Identifiers**: Sanitizes table and column names, handling spaces, special characters, and reserved keywords (e.g., `date` → `Date_dt`) automatically while guaranteeing uniqueness.
 - **Configurable Sampling**: Analyze large files efficiently without loading everything into memory
 - **Command-Line Interface**: Simple to use from the terminal
@@ -49,6 +49,9 @@ csv2ddl --dialect snowflake path/to/file.csv
 csv2ddl --dialect sqlite path/to/file.csv
 csv2ddl --dialect postgres path/to/file.csv
 csv2ddl --dialect mysql path/to/file.csv
+csv2ddl --dialect oracle path/to/file.csv
+csv2ddl --dialect sqlserver path/to/file.csv
+csv2ddl --dialect databricks path/to/file.csv
 ```
 
 ### Advanced Options
@@ -63,7 +66,7 @@ csv2ddl \
 ```
 
 ### Options
-- `--dialect`: SQL dialect (snowflake, sqlite, postgres, mysql) - default: snowflake
+- `--dialect`: SQL dialect (snowflake, sqlite, postgres, mysql, oracle, sqlserver, databricks) - default: snowflake
 - `--sample-size`: Number of rows to sample for type inference - default: 1000
 - `--output`: Output file path (optional, prints to stdout if not specified)
 - `--table-name`: Custom table name (optional, uses filename if not specified)
@@ -95,10 +98,16 @@ csv2ddl sample_data.csv --dialect snowflake --output sample_snowflake.sql
 csv2ddl sample_data.csv --dialect sqlite --output sample_sqlite.sql
 csv2ddl sample_data.csv --dialect postgres --output sample_postgres.sql
 csv2ddl sample_data.csv --dialect mysql --output sample_mysql.sql
+csv2ddl sample_data.csv --dialect oracle --output sample_oracle.sql
+csv2ddl sample_data.csv --dialect sqlserver --output sample_sqlserver.sql
+csv2ddl sample_data.csv --dialect databricks --output sample_databricks.sql
 cat sample_snowflake.sql
 cat sample_sqlite.sql
 cat sample_postgres.sql
 cat sample_mysql.sql
+cat sample_oracle.sql
+cat sample_sqlserver.sql
+cat sample_databricks.sql
 ```
 
 ### Input CSV (sample_data.csv)

--- a/tests/test_dialect_mapper.py
+++ b/tests/test_dialect_mapper.py
@@ -59,6 +59,90 @@ def test_map_mysql_string_to_text():
     assert mapped["notes"] == "TEXT"
 
 
+def test_map_oracle_string_to_clob():
+    type_info = {
+        "payload": {
+            "inferred_type": "string",
+            "parameters": {"max_length": 8000}
+        }
+    }
+
+    mapper = DialectMapper("oracle")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["payload"] == "CLOB"
+
+
+def test_map_oracle_float_precision_cap():
+    type_info = {
+        "amount": {
+            "inferred_type": "float",
+            "parameters": {"precision": 45, "scale": 6}
+        }
+    }
+
+    mapper = DialectMapper("oracle")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["amount"] == "NUMBER"
+
+
+def test_map_sqlserver_float_to_decimal():
+    type_info = {
+        "ratio": {
+            "inferred_type": "float",
+            "parameters": {"precision": 20, "scale": 8}
+        }
+    }
+
+    mapper = DialectMapper("sqlserver")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["ratio"] == "DECIMAL(20, 8)"
+
+
+def test_map_sqlserver_string_to_nvarchar_max():
+    type_info = {
+        "comment": {
+            "inferred_type": "string",
+            "parameters": {"max_length": 6000}
+        }
+    }
+
+    mapper = DialectMapper("sqlserver")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["comment"] == "NVARCHAR(MAX)"
+
+
+def test_map_databricks_integer_large_precision():
+    type_info = {
+        "identifier": {
+            "inferred_type": "integer",
+            "parameters": {"precision": 25, "scale": 0}
+        }
+    }
+
+    mapper = DialectMapper("databricks")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["identifier"] == "DECIMAL(25, 0)"
+
+
+def test_map_databricks_string_overflow_to_string():
+    type_info = {
+        "payload": {
+            "inferred_type": "string",
+            "parameters": {"max_length": 100000}
+        }
+    }
+
+    mapper = DialectMapper("databricks")
+    mapped = mapper.map_column_types(type_info)
+
+    assert mapped["payload"] == "STRING"
+
+
 def test_unsupported_dialect_raises():
     with pytest.raises(ValueError):
-        DialectMapper("oracle")
+        DialectMapper("teradata")


### PR DESCRIPTION
## Summary
- add Oracle, SQL Server, and Databricks dialect mappers with sizing heuristics for numeric and string fields
- document the new dialect options in the README usage examples and CLI options list
- extend the dialect mapper unit tests to cover the new database targets and heuristics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d81f48888322a85de0404b9ceb09